### PR TITLE
fix: rename function argument in R notebooks

### DIFF
--- a/examples-r/re3data_API_certification_by_type.ipynb
+++ b/examples-r/re3data_API_certification_by_type.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "extract_repository_info <- function(url) {\n",
+    "extract_repository_info <- function(repository_metadata_XML) {\n",
     "  list(\n",
     "    re3data_ID = xml_text(xml_find_all(repository_metadata_XML, \"//r3d:re3data.orgIdentifier\")),\n",
     "    type = paste(unique(xml_text(xml_find_all(repository_metadata_XML, \"//r3d:type\"))), collapse = \"_AND_\"),\n",

--- a/examples-r/re3data_API_medical_research_community.ipynb
+++ b/examples-r/re3data_API_medical_research_community.ipynb
@@ -97,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "extract_repository_info <- function(url) {\n",
+    "extract_repository_info <- function(repository_metadata_XML) {\n",
     "  list(\n",
     "    re3data_ID = xml_text(xml_find_all(repository_metadata_XML, \"//r3d:re3data.orgIdentifier\")),\n",
     "    repositoryName = xml_text(xml_find_all(repository_metadata_XML, \"//r3d:repositoryName\")),\n",

--- a/examples-r/re3data_API_repository_APIs.ipynb
+++ b/examples-r/re3data_API_repository_APIs.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "extract_repository_info <- function(url, API_index) {\n",
+    "extract_repository_info <- function(repository_metadata_XML, API_index) {\n",
     "  list(\n",
     "   re3data_ID = xml_text(xml_find_all(repository_metadata_XML, \"//r3d:re3data.orgIdentifier\")),\n",
     "    repositoryName = xml_text(xml_find_all(repository_metadata_XML, \"//r3d:repositoryName\")),\n",


### PR DESCRIPTION
Hi @dorothearrr, I think the argument `url` in the R notebooks should be `repository_metadata_XML`.